### PR TITLE
Fix Firebase deployment: Upgrade Node.js from 18 to 20

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         
     - name: Install Dependencies


### PR DESCRIPTION
- Firebase CLI v14.16.0 requires Node.js >=20.0.0
- GitHub Actions was using Node.js 18.20.8
- Updated workflow to use Node.js 20 for Firebase CLI compatibility

Resolves: 'Firebase CLI v14.16.0 is incompatible with Node.js v18.20.8'

🤖 Generated with [Claude Code](https://claude.ai/code)