### PR TITLE
Fix Functions npm ci error - use npm install instead

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Functions Dependencies
       run: |
         cd functions
-        npm ci
+        npm install
 
     - name: Build Functions
       run: |


### PR DESCRIPTION
GitHub Actions was failing because Functions directory doesn't have package-lock.json. Changed from npm ci to npm install for Functions dependencies installation.

🤖 Generated with [Claude Code](https://claude.ai/code)