### PR TITLE
Fix GitHub Actions permissions for Firebase preview deployment

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -8,6 +8,11 @@ on:
     branches: 
       - main
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add permissions for checks: write and pull-requests: write
- This resolves "Resource not accessible by integration" error
- Firebase action needs these permissions to create check runs and PR comments

🤖 Generated with [Claude Code](https://claude.ai/code)