### PR TITLE
Fix Firebase Functions build by preventing package.json overwrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:static": "npm run build && cd out && python3 -m http.server 8000",
     "build": "next build",
     "build:firebase": "npm run build && npm run copy-to-functions",
-    "copy-to-functions": "cp -r .next functions/ && cp next.config.js functions/ && cp package.json functions/ && cp tsconfig.json functions/ && cp -r app functions/ && cp -r components functions/ && cp -r lib functions/ && cp -r types functions/ && cp -r contexts functions/ && cp -r hooks functions/ && cp -r data functions/ && cp -r public functions/ || true",
+    "copy-to-functions": "cp -r .next functions/ && cp next.config.js functions/ && cp tsconfig.json functions/ && cp -r app functions/ && cp -r components functions/ && cp -r lib functions/ && cp -r types functions/ && cp -r contexts functions/ && cp -r hooks functions/ && cp -r data functions/ && cp -r public functions/ || true",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
The copy-to-functions script was overwriting the functions/package.json with the root package.json, causing the build script to run 'next build' instead of 'tsc'. This prevented functions/index.js from being generated.

🤖 Generated with [Claude Code](https://claude.ai/code)